### PR TITLE
Resolve issues #1 and #2 and update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,10 +39,10 @@ module.exports = function (file, opts) {
         if (typeof opts.replace[i].from === "undefined")
             throw new Error("configuration entry \"replace[" + i + "].from\" not defined");
         if (!(typeof opts.replace[i].from === "object" && opts.replace[i].from instanceof RegExp))
-            opts.replace[i].from = new RegExp(opts.replace[i].from);
+            opts.replace[i].from = new RegExp(opts.replace[i].from, 'g');
         if (typeof opts.replace[i].to === "undefined")
             throw new Error("configuration entry \"replace[" + i + "].to\" not defined");
-        if (!(typeof opts.replace[i].to === "string"))
+        if (!(typeof opts.replace[i].to === "string" || opts.replace[i].to instanceof Function))
             opts.replace[i].to = String(opts.replace[i].to);
     }
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "homepage": "https://github.com/rse/browserify-replace",
     "bugs":     "https://github.com/rse/browserify-replace/issues",
     "dependencies": {
-        "through2": "^1.1.1"
+        "through2": "^2.0.0"
     }
 }


### PR DESCRIPTION
Make string `from` values be converted into global `RegExp` objects. Support functions as `to`. Update `through2` to version `2.0.0`.
